### PR TITLE
Remove move constructor/assignment op from queue types

### DIFF
--- a/lib/fabrics/ofi/src/internal/CompletionQueue.cpp
+++ b/lib/fabrics/ofi/src/internal/CompletionQueue.cpp
@@ -85,22 +85,6 @@ namespace mxl::lib::fabrics::ofi
         close();
     }
 
-    CompletionQueue::CompletionQueue(CompletionQueue&& other) noexcept
-        : _raw(other._raw)
-    {
-        other._raw = nullptr;
-    }
-
-    CompletionQueue& CompletionQueue::operator=(CompletionQueue&& other)
-    {
-        close();
-
-        _raw = other._raw;
-        other._raw = nullptr;
-
-        return *this;
-    }
-
     ::fid_cq* CompletionQueue::raw() noexcept
     {
         return _raw;

--- a/lib/fabrics/ofi/src/internal/CompletionQueue.hpp
+++ b/lib/fabrics/ofi/src/internal/CompletionQueue.hpp
@@ -35,16 +35,11 @@ namespace mxl::lib::fabrics::ofi
 
         ~CompletionQueue();
 
-        // No copying
+        // No copying, no moving
         CompletionQueue(CompletionQueue const&) = delete;
         void operator=(CompletionQueue const&) = delete;
-
-        /// Move-constructor. A moved-from completion queue can no longer be used.
-        CompletionQueue(CompletionQueue&&) noexcept;
-
-        /// Move-assignment operator. Moving into an existing completion queue will release all of is resources
-        /// and take ownership of the resources of the moved-from completion queue.
-        CompletionQueue& operator=(CompletionQueue&&);
+        CompletionQueue(CompletionQueue&&) = delete;
+        CompletionQueue& operator=(CompletionQueue&&) = delete;
 
         ::fid_cq* raw() noexcept;
         [[nodiscard]]

--- a/lib/fabrics/ofi/src/internal/EventQueue.cpp
+++ b/lib/fabrics/ofi/src/internal/EventQueue.cpp
@@ -85,22 +85,6 @@ namespace mxl::lib::fabrics::ofi
         close();
     }
 
-    EventQueue::EventQueue(EventQueue&& other) noexcept
-        : _raw(other._raw)
-    {
-        other._raw = nullptr;
-    }
-
-    EventQueue& EventQueue::operator=(EventQueue&& other)
-    {
-        close();
-
-        _raw = other._raw;
-        other._raw = nullptr;
-
-        return *this;
-    }
-
     ::fid_eq* EventQueue::raw() noexcept
     {
         return _raw;

--- a/lib/fabrics/ofi/src/internal/EventQueue.hpp
+++ b/lib/fabrics/ofi/src/internal/EventQueue.hpp
@@ -31,16 +31,11 @@ namespace mxl::lib::fabrics::ofi
 
         ~EventQueue();
 
-        // No copying
+        // No copying, no moving
         EventQueue(EventQueue const&) = delete;
         void operator=(EventQueue const&) = delete;
-
-        /// Move constructor. A moved-from event queue can no longer be used.
-        EventQueue(EventQueue&&) noexcept;
-
-        /// Move-assigment operator. A moved-into event queue takes ownership of all resources of the
-        /// moved-from event queue. The moved-from queue can no longer be used.
-        EventQueue& operator=(EventQueue&&);
+        EventQueue(EventQueue&&) = delete;
+        EventQueue& operator=(EventQueue&&) = delete;
 
         /// Returns a raw handle to the event queue.
         ::fid_eq* raw() noexcept;


### PR DESCRIPTION
They can only be used behind a shared pointer, so there is no need to define a move constructor or move assignment operator.